### PR TITLE
fix: use GET_PRIVATE_LINK socket command for Wayland clipboard support

### DIFF
--- a/src/ownclouddolphinactionplugin.cpp
+++ b/src/ownclouddolphinactionplugin.cpp
@@ -28,6 +28,8 @@
 #include <QDir>
 #include <QTimer>
 #include <QEventLoop>
+#include <QApplication>
+#include <QClipboard>
 
 #include "ownclouddolphinpluginhelper.h"
 #include "ownclouddolphinactionplugin.h"
@@ -81,6 +83,7 @@ QList<QAction*> OwncloudDolphinPluginAction::actions(const KFileItemListProperti
             if (args.value(2).contains(QLatin1Char('d')))
                 action->setDisabled(true);
             auto call = args.value(1).toLatin1();
+            action->setData(QString::fromLatin1(call));
             connect(action, &QAction::triggered, [helper, call, files] {
                 helper->sendCommand(QByteArray(call + ":" + files + "\n"));
             });
@@ -95,6 +98,29 @@ QList<QAction*> OwncloudDolphinPluginAction::actions(const KFileItemListProperti
 
     loop.exec(QEventLoop::ExcludeUserInputEvents);
     disconnect(con);
+
+    if (OwncloudDolphinPluginHelper::isWayland()) {
+        for (auto *act : menu->actions()) {
+            if (act->data().toString() == QLatin1String("COPY_PRIVATE_LINK")) {
+                disconnect(act, &QAction::triggered, nullptr, nullptr);
+                connect(act, &QAction::triggered, parentWidget, [helper, files] {
+                    QEventLoop waitLoop;
+                    QTimer::singleShot(1000, &waitLoop, &QEventLoop::quit);
+                    auto linkCon = connect(
+                        helper, &OwncloudDolphinPluginHelper::privateLinkReceived,
+                        &waitLoop, [&waitLoop](const QString &url) {
+                            QApplication::clipboard()->setText(url);
+                            waitLoop.quit();
+                        });
+                    helper->sendCommand(QByteArray("GET_PRIVATE_LINK:") + files.split('\x1e').first() + '\n');
+                    waitLoop.exec(QEventLoop::ExcludeUserInputEvents);
+                    disconnect(linkCon);
+                });
+                break;
+            }
+        }
+    }
+
     if (menu->actions().isEmpty()) {
         delete menu;
         return {};

--- a/src/ownclouddolphinpluginhelper.cpp
+++ b/src/ownclouddolphinpluginhelper.cpp
@@ -160,6 +160,9 @@ void OwncloudDolphinPluginHelper::slotReadyRead()
             if (isLoaded) {
                 _clientIcon = pixmap;
             }
+        } else if (command == QByteArrayLiteral("PRIVATE_LINK")) {
+            Q_EMIT privateLinkReceived(QString::fromUtf8(info));
+            continue;
         }
 
         Q_EMIT commandReceived(line);

--- a/src/ownclouddolphinpluginhelper.h
+++ b/src/ownclouddolphinpluginhelper.h
@@ -54,8 +54,15 @@ public:
 
     QByteArray version() { return _version; }
 
+    static bool isWayland()
+    {
+        return !qEnvironmentVariableIsEmpty("WAYLAND_DISPLAY")
+            || qgetenv("XDG_SESSION_TYPE").toLower() == "wayland";
+    }
+
 Q_SIGNALS:
     void commandReceived(const QByteArray &cmd);
+    void privateLinkReceived(const QString &url);
 
 protected:
     void timerEvent(QTimerEvent*) override;


### PR DESCRIPTION
## Problem

On native Wayland sessions the ownCloud daemon has no compositor surface, so
`QClipboard::setText()` is silently dropped. **Copy private link to clipboard** never
works on Wayland from the Dolphin context menu.

## Solution

When the session is Wayland (`WAYLAND_DISPLAY` set or `XDG_SESSION_TYPE=wayland`), the
plugin replaces the `COPY_PRIVATE_LINK` action handler: it sends `GET_PRIVATE_LINK:<file>`
to the client (a new socket command in owncloud/client) and waits up to 1 s for
`PRIVATE_LINK:<url>`. The URL is then written via `QApplication::clipboard()->setText()`
from within the Dolphin process, which has a valid Wayland surface.

If no response arrives within the timeout (old client), the clipboard is left unchanged —
same as the current broken behaviour, with no crash or user-visible error.

Requires: owncloud/client PR for `GET_PRIVATE_LINK` command.

## Testing

- KDE Plasma on Wayland with Dolphin: right-click synced file →
  "Copy private link to clipboard" → clipboard contains the URL ✓
- X11 session: existing behaviour unchanged ✓
- Old client (no GET_PRIVATE_LINK): event loop times out cleanly ✓