### PR TITLE
ci: pin actions/checkout to SHA per org security policy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,10 @@ jobs:
     container: opensuse/tumbleweed
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Checkout resources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: owncloud/client-desktop-shell-integration-resources
           path: resources


### PR DESCRIPTION
## Summary

- Cherry-pick of dd0407454fa77a8e3ed9dd83b068c98da3e7238a
- Pins `actions/checkout` to its full SHA to comply with the org's SHA-pinning policy for GitHub Actions

## Test plan

- [ ] Verify CI workflows run successfully after the pin change
- [ ] Confirm the pinned SHA corresponds to the expected `actions/checkout` release

🤖 Generated with [Claude Code](https://claude.com/claude-code)